### PR TITLE
Forcing javadoc for assembly-jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Specified `deploy` goal in maven-release-plugin
 - Fixed "site breaking release process" (#47)
 - Fixed ossrh release requirements  (#50)
+- DummyForJavaDoc.java in assembly module to generate javadoc (#51)
 
 ## [0.3.0] - 20181211
 ### Added

--- a/assembly/src/main/java/com/homeaway/streamingplatform/streamregistry/shaded/DummyForJavaDoc.java
+++ b/assembly/src/main/java/com/homeaway/streamingplatform/streamregistry/shaded/DummyForJavaDoc.java
@@ -1,4 +1,6 @@
-/*
+/* Copyright (c) 2018 Expedia Group.
+ * All rights reserved.  http://www.homeaway.com
+
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/assembly/src/main/java/com/homeaway/streamingplatform/streamregistry/shaded/DummyForJavaDoc.java
+++ b/assembly/src/main/java/com/homeaway/streamingplatform/streamregistry/shaded/DummyForJavaDoc.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.homeaway.streamingplatform.streamregistry.shaded;
+
+/**
+ * Dummy for javadoc
+ */
+@SuppressWarnings("unused")
+public class DummyForJavaDoc {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,7 @@
                     <version>${shade.pluginVersion}</version>
                     <configuration>
                         <createDependencyReducedPom>true</createDependencyReducedPom>
+                        <createSourcesJar>true</createSourcesJar>
                         <transformers>
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Fixes #49.
Hack to force javadoc so that we can deploy to `ossrh`.

## Added
- DummyForJavaDoc.java in assembly module to generate javadoc

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
- [x] Milestone selected
- [x] PR builds successfully
