### PR TITLE
remove use of "mot"

### DIFF
--- a/core/src/main/java/com/homeaway/streamingplatform/model/RegionStreamConfig.java
+++ b/core/src/main/java/com/homeaway/streamingplatform/model/RegionStreamConfig.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 public class RegionStreamConfig {
 
     /**
-     * MOT Region where the Producer/Consumer is deployed
+     * Region where the Producer/Consumer is deployed.
      */
     @NotNull
     String region;

--- a/schema-library-events/src/main/avro/actors.avdl
+++ b/schema-library-events/src/main/avro/actors.avdl
@@ -7,7 +7,7 @@ protocol ActorProtocol {
   record Actor {
 
   /**
-  * mot app name of the actor
+  * Application name of the actor
   */
     string name;
 

--- a/schema-library-events/src/main/avro/regionReplicator.avdl
+++ b/schema-library-events/src/main/avro/regionReplicator.avdl
@@ -9,7 +9,7 @@ protocol RegionReplicatorProtocol {
   record RegionReplicator {
 
     /**
-    * This is the mot app name of the region replicator deployment
+    * This is the application name of the region replicator deployment
     */
     string appName;
 


### PR DESCRIPTION
# stream-registry PR

Removes use of "mot" in documentation. Fixes #61.

### Changed
* Documentation only, no update to changelog needed.

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
