### PR TITLE
Favor mvn exec rather than java jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # run 'STREAM_REGISTRY_DEBUG_SUSPEND=y make debug' in order to enable suspend
 STREAM_REGISTRY_DEBUG_SUSPEND ?= n
+STREAM_REGISTRY_DEBUG_PORT ?= 5105
+
+STREAM_REGISTRY_HEAP_OPTS ?= -Xmx2g
+STREAM_REGISTRY_JAVA_OPTS = $(STREAM_REGISTRY_HEAP_OPTS) -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true
+STREAM_REGISTRY_DEBUG_OPTS = $(STREAM_REGISTRY_JAVA_OPTS) -agentlib:jdwp=transport=dt_socket,server=y,suspend=$(STREAM_REGISTRY_DEBUG_SUSPEND),address=$(STREAM_REGISTRY_DEBUG_PORT)
 
 .PHONY: clean tests build run debug all just-deploy deploy ci-setup ci-deploy
 
@@ -13,10 +18,10 @@ build:
 	./mvnw clean install -B
 
 run:
-	java -Xmx2G -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true -jar assembly/target/stream-registry*SNAPSHOT.jar server config-dev.yaml
+	MAVEN_OPTS="$(STREAM_REGISTRY_JAVA_OPTS)" ./mvnw exec:java
 
 debug:
-	java -Xmx2G -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=$(STREAM_REGISTRY_DEBUG_SUSPEND),address=5105 -jar assembly/target/stream-registry*SNAPSHOT.jar server config-dev.yaml
+	MAVEN_OPTS="$(STREAM_REGISTRY_DEBUG_OPTS)" ./mvnw exec:java
 
 all: build
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <surefire.pluginVersion>2.20.1</surefire.pluginVersion>
         <surefire-junit4.version>2.20.1</surefire-junit4.version>
         <build-helper.maven.plugin.version>3.0.0</build-helper.maven.plugin.version>
-
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 
         <!-- OSSRH -->
         <nexusStaging.pluginVersion>1.6.7</nexusStaging.pluginVersion>
@@ -630,6 +630,32 @@
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
+                    <configuration>
+                        <mainClass>${mainClass}</mainClass>
+                        <includePluginDependencies>true</includePluginDependencies>
+                        <arguments>
+                            <!-- Standard Dropwizard app arguments -->
+                            <argument>server</argument>
+                            <argument>${project.basedir}/config-dev.yaml</argument>
+                        </arguments>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>stream-registry-core</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>kafka-infra-provider</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# stream-registry PR

Manual invocation of `java jar` could potentially have classpath issues and stale artifacts can exist under `assembly/target`. Using Maven to run the main class, we are guaranteed for everything to be accurate. 

### Added
* `exec-maven-plugin`

### Changed
* `Makefile` run and debug targets


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
