### PR TITLE
Fixing unused stream name path param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.4.1] - SNAPSHOT
+### Changed
+- Adding un-annotated `streamName` path param to streamUpsert HTTP resource (#69)
+
 ### Removed
-- Deleted TODO/Documentation that referenced incorrect `http://localhost:8081/healthcheck` (#64 )
+- Deleted TODO/Documentation that referenced incorrect `http://localhost:8081/healthcheck` (#64)
 
 ## [0.4.0] - 20181218
 ### Added

--- a/core/src/main/java/com/homeaway/streamingplatform/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamingplatform/health/StreamRegistryHealthCheck.java
@@ -151,7 +151,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private void validateCreateStream() {
         try {
             Stream streamRegHealthCheckStream = createCanaryStream();
-            Response response = streamResource.upsertStream(streamRegHealthCheckStream, HEALTH_CHECK_STREAM_NAME);
+            Response response = streamResource.upsertStream(HEALTH_CHECK_STREAM_NAME, streamRegHealthCheckStream);
             if (response.getStatus() != 202) {
                 setStreamCreationHealthy(false);
                 throw new IllegalStateException("HealthCheck Failed: Error while upserting a Stream.");

--- a/core/src/main/java/com/homeaway/streamingplatform/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamingplatform/health/StreamRegistryHealthCheck.java
@@ -56,7 +56,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     public static final Integer PRODUCT_ID = 126845;
     public static final String COMPONENT_ID = "986bef24-0e0d-43aa-adc8-bd39702edd9a";
     public static final String APP_NAME = "StreamRegistryApplication";
-    private static final String STREAM_NAME = "StreamRegistryHealthCheck";
+    private static final String HEALTH_CHECK_STREAM_NAME = "StreamRegistryHealthCheck";
 
     private final ManagedKStreams managedKStreams;
     private final StreamResource streamResource;
@@ -151,7 +151,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private void validateCreateStream() {
         try {
             Stream streamRegHealthCheckStream = createCanaryStream();
-            Response response = streamResource.upsertStream(streamRegHealthCheckStream);
+            Response response = streamResource.upsertStream(streamRegHealthCheckStream, HEALTH_CHECK_STREAM_NAME);
             if (response.getStatus() != 202) {
                 setStreamCreationHealthy(false);
                 throw new IllegalStateException("HealthCheck Failed: Error while upserting a Stream.");
@@ -165,7 +165,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private Stream createCanaryStream() {
         return Stream.builder()
-                .name(STREAM_NAME)
+                .name(HEALTH_CHECK_STREAM_NAME)
                 .schemaCompatibility(SchemaCompatibility.TRANSITIVE_BACKWARD)
                 .latestKeySchema(createSampleSchema())
                 .latestValueSchema(createSampleSchema())
@@ -194,9 +194,9 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateStateStore() {
         try {
-            AvroStreamKey avroStreamKey = AvroStreamKey.newBuilder().setStreamName(STREAM_NAME).build();
+            AvroStreamKey avroStreamKey = AvroStreamKey.newBuilder().setStreamName(HEALTH_CHECK_STREAM_NAME).build();
             Optional<AvroStream> avroStreamValue = managedKStreams.getAvroStreamForKey(avroStreamKey);
-            if(!avroStreamValue.isPresent() || ! avroStreamValue.get().getName().equals(STREAM_NAME)) {
+            if(!avroStreamValue.isPresent() || ! avroStreamValue.get().getName().equals(HEALTH_CHECK_STREAM_NAME)) {
                 setStateStoreHealthy(false);
                 throw new IllegalStateException("HealthCheck Failed: StreamRegistryHealthCheck Stream not available in StateStore.");
             }
@@ -227,7 +227,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
         try {
             ProducerResource producerResource = streamResource.getProducerResource();
             String producerName = "P1";
-            Response response = producerResource.upsertProducer(STREAM_NAME, producerName, region);
+            Response response = producerResource.upsertProducer(HEALTH_CHECK_STREAM_NAME, producerName, region);
             List<RegionStreamConfig> regionStreamConfigList = ((Producer)response.getEntity()).getRegionStreamConfigList();
 
             if (regionStreamConfigList != null && regionStreamConfigList.size() > 0) {
@@ -261,7 +261,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
         try {
             ConsumerResource consumerResource = streamResource.getConsumerResource();
             String consumerName = "C1";
-            Response response = consumerResource.upsertConsumer(STREAM_NAME, consumerName, region);
+            Response response = consumerResource.upsertConsumer(HEALTH_CHECK_STREAM_NAME, consumerName, region);
             List<RegionStreamConfig> regionStreamConfigList = ((Consumer)response.getEntity()).getRegionStreamConfigList();
 
             if (regionStreamConfigList != null && regionStreamConfigList.size() > 0) {

--- a/core/src/main/java/com/homeaway/streamingplatform/resource/StreamResource.java
+++ b/core/src/main/java/com/homeaway/streamingplatform/resource/StreamResource.java
@@ -85,8 +85,8 @@ public class StreamResource {
     @Path("/{streamName}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
-    public Response upsertStream(@ApiParam(value = "stream entity", required = true) Stream stream,
-                                 @ApiParam(value = "stream name", required = true) @PathParam("streamName") String streamName) {
+    public Response upsertStream(@ApiParam(value = "stream name", required = true) @PathParam("streamName") String streamName,
+                                 @ApiParam(value = "stream entity", required = true) Stream stream) {
 
         try {
             if (!stream.getName().equals(streamName)) {

--- a/core/src/test/java/com/homeaway/streamingplatform/extensions/schema/SchemaManagerIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/extensions/schema/SchemaManagerIT.java
@@ -33,7 +33,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
 
         // re-check compatibility for same schema (new field with default value)
         String newSchema = "{\"namespace\":\"com.homeaway\",\"type\":\"record\",\"name\":\"user\",\"fields\":" +
@@ -49,7 +49,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
 
         stream.getLatestValueSchema().setSchemaString(stream.getLatestKeySchema().getSchemaString());
         Response response = streamResource.validateStreamCompatibility(stream, streamName, "default");
@@ -75,7 +75,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
@@ -90,12 +90,12 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         String schemaString = "this is not valid json";
         stream.getLatestValueSchema().setSchemaString(schemaString);
-        response = streamResource.upsertStream(stream, streamName);
+        response = streamResource.upsertStream(streamName, stream);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
@@ -105,14 +105,14 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // incompatible schema
         stream.getLatestValueSchema().setSchemaString(stream.getLatestKeySchema().getSchemaString());
-        response = streamResource.upsertStream(stream, streamName);
+        response = streamResource.upsertStream(streamName, stream);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
@@ -133,7 +133,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
 
         // re-check compatibility for same schema
         Response response = streamResource.validateStreamCompatibility(stream, streamName, "default");

--- a/core/src/test/java/com/homeaway/streamingplatform/extensions/schema/SchemaManagerIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/extensions/schema/SchemaManagerIT.java
@@ -33,7 +33,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
 
         // re-check compatibility for same schema (new field with default value)
         String newSchema = "{\"namespace\":\"com.homeaway\",\"type\":\"record\",\"name\":\"user\",\"fields\":" +
@@ -49,7 +49,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
 
         stream.getLatestValueSchema().setSchemaString(stream.getLatestKeySchema().getSchemaString());
         Response response = streamResource.validateStreamCompatibility(stream, streamName, "default");
@@ -75,7 +75,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
@@ -90,12 +90,12 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         String schemaString = "this is not valid json";
         stream.getLatestValueSchema().setSchemaString(schemaString);
-        response = streamResource.upsertStream(stream);
+        response = streamResource.upsertStream(stream, streamName);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
@@ -105,14 +105,14 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
         Assert.assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // incompatible schema
         stream.getLatestValueSchema().setSchemaString(stream.getLatestKeySchema().getSchemaString());
-        response = streamResource.upsertStream(stream);
+        response = streamResource.upsertStream(stream, streamName);
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
@@ -133,7 +133,7 @@ public class SchemaManagerIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
         // create stream/register schema
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
 
         // re-check compatibility for same schema
         Response response = streamResource.validateStreamCompatibility(stream, streamName, "default");

--- a/core/src/test/java/com/homeaway/streamingplatform/extensions/validator/StreamValidatorIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/extensions/validator/StreamValidatorIT.java
@@ -69,7 +69,7 @@ public class StreamValidatorIT extends BaseResourceIT {
     public void test_upsertStream_InvalidProductId() {
         String streamName = "junit-stream-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, INVALID_PRODUCT_ID, Optional.empty(), JsonModelBuilder.TEST_HINT);
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }

--- a/core/src/test/java/com/homeaway/streamingplatform/extensions/validator/StreamValidatorIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/extensions/validator/StreamValidatorIT.java
@@ -69,7 +69,7 @@ public class StreamValidatorIT extends BaseResourceIT {
     public void test_upsertStream_InvalidProductId() {
         String streamName = "junit-stream-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, INVALID_PRODUCT_ID, Optional.empty(), JsonModelBuilder.TEST_HINT);
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/ConsumerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/ConsumerResourceIT.java
@@ -64,7 +64,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response streamResponse = streamResource.upsertStream(stream, streamName);
+        Response streamResponse = streamResource.upsertStream(streamName, stream);
         assertThat(streamResponse.getStatus(), is(202));
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
@@ -95,7 +95,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         consumerResource.upsertConsumer(streamName, consumerName, US_EAST_REGION);
@@ -124,7 +124,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
-        Response streamResponse = streamResource.upsertStream(stream, streamName);
+        Response streamResponse = streamResource.upsertStream(streamName, stream);
         assertThat(streamResponse.getStatus(), is(202));
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
@@ -144,7 +144,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         String invalidRegion="invalid-region";
@@ -171,7 +171,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String unsupported_region = "ap-southeast-1-vpc-3f07915b";
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
         Response response = consumerResource.upsertConsumer(streamName, consumerName, unsupported_region);
@@ -185,7 +185,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
         assertThat(response.getStatus(), is(202));
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
@@ -217,7 +217,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         consumerResource.upsertConsumer(streamName, consumerName, US_EAST_REGION);

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/ConsumerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/ConsumerResourceIT.java
@@ -64,7 +64,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response streamResponse = streamResource.upsertStream(stream);
+        Response streamResponse = streamResource.upsertStream(stream, streamName);
         assertThat(streamResponse.getStatus(), is(202));
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
@@ -95,7 +95,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         consumerResource.upsertConsumer(streamName, consumerName, US_EAST_REGION);
@@ -124,7 +124,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
-        Response streamResponse = streamResource.upsertStream(stream);
+        Response streamResponse = streamResource.upsertStream(stream, streamName);
         assertThat(streamResponse.getStatus(), is(202));
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
@@ -144,7 +144,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         String invalidRegion="invalid-region";
@@ -171,7 +171,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String unsupported_region = "ap-southeast-1-vpc-3f07915b";
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
         Response response = consumerResource.upsertConsumer(streamName, consumerName, unsupported_region);
@@ -185,7 +185,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
         String consumerName = "C1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
         assertThat(response.getStatus(), is(202));
 
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
@@ -217,7 +217,7 @@ public class ConsumerResourceIT extends BaseResourceIT {
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
 
         consumerResource.upsertConsumer(streamName, consumerName, US_EAST_REGION);

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/ProducerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/ProducerResourceIT.java
@@ -57,7 +57,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         //Step 1: PUT a stream
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         // Step 2: Validate "Producer Not Found" for a Stream.
@@ -94,7 +94,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
@@ -105,7 +105,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Assert.assertEquals(1, ((Producer) producerResponse.getEntity()).getRegionStreamConfigList().size());
 
         // double registration
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
@@ -122,7 +122,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
         //Step 1: PUT a stream
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // Step 2: Upsert a producer
@@ -146,7 +146,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS*2);
 
         Assert.assertEquals(streamName, ((Stream) streamResource.getStream(streamName).getEntity()).getName());
@@ -174,7 +174,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String unsupported_region = "ap-southeast-1-vpc-3f07915b";
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response response = producerResource.upsertProducer(streamName, producerName, unsupported_region);
@@ -189,7 +189,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
@@ -220,7 +220,7 @@ public class ProducerResourceIT extends BaseResourceIT {
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
         assertThat(response.getStatus(), is(202));
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
@@ -244,8 +244,8 @@ public class ProducerResourceIT extends BaseResourceIT {
         Stream stream1 = JsonModelBuilder.buildJsonStream(streamName1);
         Stream stream2 = JsonModelBuilder.buildJsonStream(streamName2);
 
-        streamResource.upsertStream(stream1);
-        streamResource.upsertStream(stream2);
+        streamResource.upsertStream(stream1, streamName1);
+        streamResource.upsertStream(stream2, streamName2);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         producerResource.upsertProducer(streamName1, producerName1, US_EAST_REGION);

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/ProducerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/ProducerResourceIT.java
@@ -57,7 +57,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         //Step 1: PUT a stream
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         // Step 2: Validate "Producer Not Found" for a Stream.
@@ -94,7 +94,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
@@ -105,7 +105,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Assert.assertEquals(1, ((Producer) producerResponse.getEntity()).getRegionStreamConfigList().size());
 
         // double registration
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
@@ -122,7 +122,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
         //Step 1: PUT a stream
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // Step 2: Upsert a producer
@@ -146,7 +146,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P2";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS*2);
 
         Assert.assertEquals(streamName, ((Stream) streamResource.getStream(streamName).getEntity()).getName());
@@ -174,7 +174,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String unsupported_region = "ap-southeast-1-vpc-3f07915b";
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response response = producerResource.upsertProducer(streamName, producerName, unsupported_region);
@@ -189,7 +189,7 @@ public class ProducerResourceIT extends BaseResourceIT {
         String producerName = "P1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         producerResource.upsertProducer(streamName, producerName, US_EAST_REGION);
@@ -220,7 +220,7 @@ public class ProducerResourceIT extends BaseResourceIT {
 
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
         assertThat(response.getStatus(), is(202));
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
@@ -244,8 +244,8 @@ public class ProducerResourceIT extends BaseResourceIT {
         Stream stream1 = JsonModelBuilder.buildJsonStream(streamName1);
         Stream stream2 = JsonModelBuilder.buildJsonStream(streamName2);
 
-        streamResource.upsertStream(stream1, streamName1);
-        streamResource.upsertStream(stream2, streamName2);
+        streamResource.upsertStream(streamName1, stream1);
+        streamResource.upsertStream(streamName2, stream2);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         producerResource.upsertProducer(streamName1, producerName1, US_EAST_REGION);

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/StreamResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/StreamResourceIT.java
@@ -43,7 +43,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-create-new-stream";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -61,7 +61,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-with-region";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
         List<String> vpcList = Collections.singletonList(US_EAST_REGION);
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -77,7 +77,7 @@ public class StreamResourceIT extends BaseResourceIT {
         List<String> replicatedVpcList = Collections.singletonList(US_EAST_REGION);
         stream.setReplicatedVpcList(replicatedVpcList);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -97,7 +97,7 @@ public class StreamResourceIT extends BaseResourceIT {
         topicConfig.put(BaseResourceIT.REPLICATION_FACTOR, String.valueOf(1));
 
         stream.setTopicConfig(topicConfig);
-        Response response= streamResource.upsertStream(stream, streamName);
+        Response response= streamResource.upsertStream(streamName, stream);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -107,7 +107,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-upsert-existing-stream";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -116,7 +116,7 @@ public class StreamResourceIT extends BaseResourceIT {
 
         // Update the stream and UPSERT it.
         stream.setOwner("user-2");
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         streamResponse = streamResource.getStream(streamName);
@@ -133,7 +133,7 @@ public class StreamResourceIT extends BaseResourceIT {
     public void test_upsertStream_null_stream_name() {
         Stream stream = JsonModelBuilder.buildJsonStream(null);
 
-        Response response = streamResource.upsertStream(stream, null);
+        Response response = streamResource.upsertStream(null, stream);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -153,8 +153,8 @@ public class StreamResourceIT extends BaseResourceIT {
         Stream stream1 = JsonModelBuilder.buildJsonStream(streamName1);
         Stream stream2 = JsonModelBuilder.buildJsonStream(streamName2);
 
-        streamResource.upsertStream(stream1, streamName1);
-        streamResource.upsertStream(stream2, streamName2);
+        streamResource.upsertStream(streamName1, stream1);
+        streamResource.upsertStream(streamName2, stream2);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // Two streams should be in the first 10 elements of page 0
@@ -173,7 +173,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-delete-stream-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         streamResource.deleteStream(streamName);
@@ -190,7 +190,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-create-stream-with-tags";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -216,7 +216,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String HINT_SWAGGER = "string";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), HINT_SWAGGER);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -229,7 +229,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String OTHER_HINT = "other-alias";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -256,14 +256,14 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-upsert-stream-componentid-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         String updatedComponentId = UUID.randomUUID().toString();
 
         Stream updatedStream = JsonModelBuilder.buildJsonStream(streamName, updatedComponentId);
 
-        streamResource.upsertStream(updatedStream, streamName);
+        streamResource.upsertStream(streamName, updatedStream);
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
@@ -288,7 +288,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-upsert-stream-automation-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response streamResponse = streamResource.upsertStream(stream, streamName);
+        Response streamResponse = streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
         if(streamResponse.getEntity() instanceof String) {
             throw new IllegalStateException("Expected String entity. Instead response=" + streamResponse.getEntity());
@@ -319,12 +319,12 @@ public class StreamResourceIT extends BaseResourceIT {
         int startingPartitions = 3;
         stream.setPartitions(startingPartitions);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         int updatePartitions = 2;
         stream.setPartitions(updatePartitions);
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -336,12 +336,12 @@ public class StreamResourceIT extends BaseResourceIT {
         int startingReplicationFactor = 3;
         stream.setReplicationFactor(startingReplicationFactor);
 
-        streamResource.upsertStream(stream, streamName);
+        streamResource.upsertStream(streamName, stream);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         int updateReplicationFactor = 4;
         stream.setReplicationFactor(updateReplicationFactor);
-        Response response = streamResource.upsertStream(stream, streamName);
+        Response response = streamResource.upsertStream(streamName, stream);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }

--- a/core/src/test/java/com/homeaway/streamingplatform/resource/StreamResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamingplatform/resource/StreamResourceIT.java
@@ -43,7 +43,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-create-new-stream";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -61,7 +61,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-with-region";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
         List<String> vpcList = Collections.singletonList(US_EAST_REGION);
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -77,7 +77,7 @@ public class StreamResourceIT extends BaseResourceIT {
         List<String> replicatedVpcList = Collections.singletonList(US_EAST_REGION);
         stream.setReplicatedVpcList(replicatedVpcList);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -97,7 +97,7 @@ public class StreamResourceIT extends BaseResourceIT {
         topicConfig.put(BaseResourceIT.REPLICATION_FACTOR, String.valueOf(1));
 
         stream.setTopicConfig(topicConfig);
-        Response response= streamResource.upsertStream(stream);
+        Response response= streamResource.upsertStream(stream, streamName);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -107,7 +107,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-upsert-existing-stream";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -116,7 +116,7 @@ public class StreamResourceIT extends BaseResourceIT {
 
         // Update the stream and UPSERT it.
         stream.setOwner("user-2");
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         streamResponse = streamResource.getStream(streamName);
@@ -133,7 +133,7 @@ public class StreamResourceIT extends BaseResourceIT {
     public void test_upsertStream_null_stream_name() {
         Stream stream = JsonModelBuilder.buildJsonStream(null);
 
-        Response response= streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, null);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -153,8 +153,8 @@ public class StreamResourceIT extends BaseResourceIT {
         Stream stream1 = JsonModelBuilder.buildJsonStream(streamName1);
         Stream stream2 = JsonModelBuilder.buildJsonStream(streamName2);
 
-        streamResource.upsertStream(stream1);
-        streamResource.upsertStream(stream2);
+        streamResource.upsertStream(stream1, streamName1);
+        streamResource.upsertStream(stream2, streamName2);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         // Two streams should be in the first 10 elements of page 0
@@ -173,7 +173,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-delete-stream-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         streamResource.deleteStream(streamName);
@@ -190,7 +190,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-stream-create-stream-with-tags";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -216,7 +216,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String HINT_SWAGGER = "string";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), HINT_SWAGGER);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -229,7 +229,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String OTHER_HINT = "other-alias";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName, JsonModelBuilder.TEST_PRODUCT_ID, Optional.of(TEST_COMPONENT_ID), OTHER_HINT);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         Response streamResponse = streamResource.getStream(streamName);
@@ -256,14 +256,14 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-upsert-stream-componentid-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS); // wait so that the Topology can process it and materialize to KV-Store
 
         String updatedComponentId = UUID.randomUUID().toString();
 
         Stream updatedStream = JsonModelBuilder.buildJsonStream(streamName, updatedComponentId);
 
-        streamResource.upsertStream(updatedStream);
+        streamResource.upsertStream(updatedStream, streamName);
 
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
@@ -288,7 +288,7 @@ public class StreamResourceIT extends BaseResourceIT {
         String streamName = "junit-upsert-stream-automation-1";
         Stream stream = JsonModelBuilder.buildJsonStream(streamName);
 
-        Response streamResponse = streamResource.upsertStream(stream);
+        Response streamResponse = streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
         if(streamResponse.getEntity() instanceof String) {
             throw new IllegalStateException("Expected String entity. Instead response=" + streamResponse.getEntity());
@@ -319,12 +319,12 @@ public class StreamResourceIT extends BaseResourceIT {
         int startingPartitions = 3;
         stream.setPartitions(startingPartitions);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         int updatePartitions = 2;
         stream.setPartitions(updatePartitions);
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -336,12 +336,12 @@ public class StreamResourceIT extends BaseResourceIT {
         int startingReplicationFactor = 3;
         stream.setReplicationFactor(startingReplicationFactor);
 
-        streamResource.upsertStream(stream);
+        streamResource.upsertStream(stream, streamName);
         Thread.sleep(TEST_SLEEP_WAIT_MS);
 
         int updateReplicationFactor = 4;
         stream.setReplicationFactor(updateReplicationFactor);
-        Response response = streamResource.upsertStream(stream);
+        Response response = streamResource.upsertStream(stream, streamName);
 
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }


### PR DESCRIPTION
Addresses #66 

# stream-registry PR

Path param in PUT /v0/streams/{streamName} resource isn't annotated and used as a path param, causing problems downstream for clients whose APIs are generated via the stream registry swagger (in certain places curly braces are left unencoded in HTTP requests)

### Changed
* Added `streamName` as an annotated path param as second argument of stream upsert method in StreamResource

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
