### PR TITLE
documentation: fix repo name

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Stream Registry Documentation
 site_description: 'Open Source Docs and Community Standards'
 site_author: 'Digital Platform'
 site_url: 'https://homeaway.github.io/stream-registry'
-repo_name: 'streamingplatform/stream-registry'
+repo_name: 'homeaway/stream-registry'
 repo_url: 'https://github.com/HomeAway/stream-registry/'
 edit_uri: 'edit/master/docs/docs/'
 theme:


### PR DESCRIPTION
# stream-registry PR

This is just fixing the repo name in the docs. See screenshot below:

<img width="721" alt="screenshot 2019-01-17 at 23 56 20" src="https://user-images.githubusercontent.com/181959/51356744-b59dda00-1ab3-11e9-93e8-2b7f6c86f0c5.png">

### Fixed

* repo name in the docs


# PR Checklist Forms

- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
