### PR TITLE
Doc typo

### DIFF
--- a/docs/docs/architecture/index.md
+++ b/docs/docs/architecture/index.md
@@ -22,7 +22,7 @@ For example, the stream-registry will likely be open sourced with a
 `generic-kafka-stream-provider` to work with the Apache Kafka stream platform
 in a generic manner.  Chances are, that Acme Inc, might want to expand on this
 generic functionality and add Acme-specific ConfigMaps and functionality.
-They can do so by extending `generic-kafa-stream-provider` to come up with
+They can do so by extending `generic-kafka-stream-provider` to come up with
 an `acme-kafka-stream-provider`.
 
 These stream providers are typically jar files that have classes that


### PR DESCRIPTION
s/kafa/kafka/

It's Kafka after all :)