### PR TITLE
Publish the docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.4.4] - SNAPSHOT
+### Changed
+- Jib now publishes docker image to dockerhub
 
 ## [0.4.3] - 20190131
 ### Changed

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -92,9 +92,9 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>dockerBuild</id>
+                                <id>dockerBuildAndPush</id>
                                 <goals>
-                                    <goal>dockerBuild</goal>
+                                    <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>


### PR DESCRIPTION
- Fixes #77

# stream-registry PR

Changes jib to build **and publish** docker image to dockerhub.

### Changed
* Jib now publishes docker image to dockerhub

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
