### PR TITLE
Hardening check for ensuring KStream store is available during IT phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Populated the HealthCheck stream region from config file. Removed the dependency of MPAAS_REGION variable. (#103)
 - Refactored the Exception handling workflow in order to better communicate the actual error to customers. (#111)
-- Hardening check for ensuring KStream store is available during Integration Tests
+- Hardening check for ensuring KStream store is available during Integration Tests. (#102)
 
 ## [0.4.4] - 20190204
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.5] - SNAPSHOT
 ### Changed
+- Hardening check for ensuring KStream store is available during Integration Tests
 
 ## [0.4.4] - 20190204
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.5] - SNAPSHOT
 ### Changed
-- Hardening check for ensuring KStream store is available during Integration Tests
 - Populated the HealthCheck stream region from config file. Removed the dependency of MPAAS_REGION variable. (#103)
+- Refactored the Exception handling workflow in order to better communicate the actual error to customers. (#111)
+- Hardening check for ensuring KStream store is available during Integration Tests
 
 ## [0.4.4] - 20190204
 ### Changed

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -59,6 +59,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     public static final Integer PRODUCT_ID = 126845;
     public static final String COMPONENT_ID = "986bef24-0e0d-43aa-adc8-bd39702edd9a";
     public static final String APP_NAME = "StreamRegistryApplication";
+    private static final String HEALTH_CHECK_STREAM_NAME = "StreamRegistryHealthCheck";
 
     private final ManagedKStreams managedKStreams;
     private final StreamResource streamResource;

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -75,6 +75,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private int partitions;
 
     private ProducerResource producerResource;
+    private Stream streamRegHealthCheckStream;
 
     /**
      * Constructor called from BaseResourceIT.java for overriding the
@@ -103,6 +104,9 @@ public class StreamRegistryHealthCheck extends HealthCheck {
         metricRegistry.register(Metrics.PRODUCER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isProducerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.CONSUMER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isConsumerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.STATE_STORE_STATE.getName(), (Gauge<String>)() -> getKstreamsState().toString());
+
+        streamRegHealthCheckStream = createCanaryStream();
+        streamResource.upsertStream(streamName, streamRegHealthCheckStream);
 
         producerResource = streamResource.getProducerResource();
         String producerName = "P1";
@@ -171,7 +175,6 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateCreateStream() {
         try {
-            Stream streamRegHealthCheckStream = createCanaryStream();
             Response response = streamResource.upsertStream(streamName, streamRegHealthCheckStream);
             if (response.getStatus() != 202) {
                 setStreamCreationHealthy(false);

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -72,6 +72,8 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private String region;
     private int healthcheckStreamReplicationFactor;
 
+    private ProducerResource producerResource;
+
     /**
      * Constructor called from BaseResourceIT.java for overriding the
      *      replication-factor to 1 - there is only one broker in IntegrationTest cluster
@@ -97,6 +99,10 @@ public class StreamRegistryHealthCheck extends HealthCheck {
         metricRegistry.register(Metrics.PRODUCER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isProducerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.CONSUMER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isConsumerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.STATE_STORE_STATE.getName(), (Gauge<String>)() -> getKstreamsState().toString());
+
+        producerResource = streamResource.getProducerResource();
+        String producerName = "P1";
+        producerResource.upsertProducer(HEALTH_CHECK_STREAM_NAME, producerName, region);
     }
 
     public StreamRegistryHealthCheck(ManagedKStreams managedKStreams, StreamResource streamResource, MetricRegistry metricRegistry) {
@@ -249,9 +255,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateProducerRegistration() {
         try {
-            ProducerResource producerResource = streamResource.getProducerResource();
-            String producerName = "P1";
-            Response response = producerResource.upsertProducer(HEALTH_CHECK_STREAM_NAME, producerName, region);
+            Response response = producerResource.getProducer(HEALTH_CHECK_STREAM_NAME, "P1");
 
             if(response.getStatus() != Status.OK.getStatusCode()) {
                 setProducerRegistrationHealthy(false);

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -78,11 +78,6 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private ProducerResource producerResource;
     private ConsumerResource consumerResource;
 
-    /**
-     * Constructor called from BaseResourceIT.java for overriding the
-     *      replication-factor to 1 - there is only one broker in IntegrationTest cluster
-     *      region - Build environment does not have MPAAS_REGION env variables.
-     */
     public StreamRegistryHealthCheck(ManagedKStreams managedKStreams, StreamResource streamResource, MetricRegistry metricRegistry,
                                      HealthCheckStreamConfig healthCheckStreamConfig) {
         super();

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -59,7 +59,6 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     public static final Integer PRODUCT_ID = 126845;
     public static final String COMPONENT_ID = "986bef24-0e0d-43aa-adc8-bd39702edd9a";
     public static final String APP_NAME = "StreamRegistryApplication";
-    private static final String HEALTH_CHECK_STREAM_NAME = "StreamRegistryHealthCheck";
 
     private final ManagedKStreams managedKStreams;
     private final StreamResource streamResource;
@@ -107,7 +106,7 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
         producerResource = streamResource.getProducerResource();
         String producerName = "P1";
-        producerResource.upsertProducer(HEALTH_CHECK_STREAM_NAME, producerName, region);
+        producerResource.upsertProducer(this.streamName, producerName, region);
     }
 
     private synchronized boolean isStreamCreationHealthy() {
@@ -255,11 +254,11 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateProducerRegistration() {
         try {
-            Response response = producerResource.getProducer(HEALTH_CHECK_STREAM_NAME, "P1");
+            Response response = producerResource.getProducer(this.streamName, "P1");
 
             if(response.getStatus() != Status.OK.getStatusCode()) {
                 setProducerRegistrationHealthy(false);
-                throw new IllegalStateException(String.format("HealthCheck Failed: Producer Registration Failed. HEALTH_CHECK_STREAM_NAME=%s not found", HEALTH_CHECK_STREAM_NAME));
+                throw new IllegalStateException(String.format("HealthCheck Failed: Producer Registration Failed. HEALTH_CHECK_STREAM_NAME=%s not found", this.streamName));
             }
 
             List<RegionStreamConfig> regionStreamConfigList = ((Producer)response.getEntity()).getRegionStreamConfigList();

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -251,6 +252,12 @@ public class StreamRegistryHealthCheck extends HealthCheck {
             ProducerResource producerResource = streamResource.getProducerResource();
             String producerName = "P1";
             Response response = producerResource.upsertProducer(HEALTH_CHECK_STREAM_NAME, producerName, region);
+
+            if(response.getStatus() != Status.OK.getStatusCode()) {
+                setProducerRegistrationHealthy(false);
+                throw new IllegalStateException(String.format("HealthCheck Failed: Producer Registration Failed. HEALTH_CHECK_STREAM_NAME=%s not found", HEALTH_CHECK_STREAM_NAME));
+            }
+
             List<RegionStreamConfig> regionStreamConfigList = ((Producer)response.getEntity()).getRegionStreamConfigList();
 
             if (regionStreamConfigList != null && regionStreamConfigList.size() > 0) {

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -236,7 +236,7 @@ public class BaseResourceIT {
         while (!initialized.isDone() && System.currentTimeMillis() <= timeoutTimestamp) {
             Thread.sleep(10); // wait some cycles before checking again
         }
-        Preconditions.checkState(System.currentTimeMillis() <= timeoutTimestamp,
+        Preconditions.checkState(initialized.isDone(),
             "Did not receive state store initialized signal, aborting.");
         log.info("sleep completed.");
 

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -47,7 +47,6 @@ import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.ZkConnection;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -239,7 +238,7 @@ public class BaseResourceIT {
         }
         Preconditions.checkState(
         		initialized.isDone() &&
-        		isAcceptableKStreamState(managedKStreams.getStreams().state()),
+                managedKStreams.getStreams().state().isRunning(),
         		"Did not receive state store initialized signal, aborting.");
         log.info("sleep completed.");
 
@@ -354,11 +353,5 @@ public class BaseResourceIT {
         managedKafkaProducer.stop();
         infraManager.stop();
         ZKCLIENT.close();
-    }
-
-    private static boolean isAcceptableKStreamState(State state) {
-		return (state != State.ERROR &&
-				state != State.PENDING_SHUTDOWN &&
-				state != State.NOT_RUNNING);
     }
 }

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -231,14 +231,14 @@ public class BaseResourceIT {
         consumerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryURL);
 
         log.info(
-            "sleep started. Sleep needed so that the processor's init method is called (KV store created) before servicing the HTTP requests.");
+            "Waiting for processor's init method tob called (KV store created) before servicing the HTTP requests.");
         long timeoutTimestamp = System.currentTimeMillis() + TEST_STARTUP_TIMEOUT_MS;
         while (!initialized.isDone() && System.currentTimeMillis() <= timeoutTimestamp) {
             Thread.sleep(10); // wait some cycles before checking again
         }
-        Preconditions.checkState(initialized.isDone() && managedKStreams.getStreams().state().isRunning(),
-        		"Did not receive state store initialized signal, aborting.");
-        log.info("sleep completed.");
+        Preconditions.checkState(initialized.isDone(), "Did not receive state store initialized signal, aborting.");
+        Preconditions.checkState(managedKStreams.getStreams().state().isRunning(), "State store did not start. Aborting.");
+        log.info("Processor wait completed.");
 
         KafkaManager kafkaManager = new KafkaManagerImpl();
         String env = configuration.getEnv();

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -236,9 +236,7 @@ public class BaseResourceIT {
         while (!initialized.isDone() && System.currentTimeMillis() <= timeoutTimestamp) {
             Thread.sleep(10); // wait some cycles before checking again
         }
-        Preconditions.checkState(
-        		initialized.isDone() &&
-                managedKStreams.getStreams().state().isRunning(),
+        Preconditions.checkState(initialized.isDone() && managedKStreams.getStreams().state().isRunning(),
         		"Did not receive state store initialized signal, aborting.");
         log.info("sleep completed.");
 

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -233,7 +233,7 @@ public class BaseResourceIT {
         consumerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryURL);
 
         log.info(
-            "Waiting for processor's init method tob called (KV store created) before servicing the HTTP requests.");
+            "Waiting for processor's init method to be called (KV store created) before servicing the HTTP requests.");
         long timeoutTimestamp = System.currentTimeMillis() + TEST_STARTUP_TIMEOUT_MS;
         while (!initialized.isDone() && System.currentTimeMillis() <= timeoutTimestamp) {
             Thread.sleep(10); // wait some cycles before checking again


### PR DESCRIPTION
# stream-registry PR

Hardening Travis Build [#435](https://travis-ci.org/homeaway/stream-registry/builds/488854536) failure

### Changed
* Updated check to ensure KStream store is available during Integration Tests
* Updated StreamRegistryHealthCheck impl to instantiate infra building blocks ( health check stream, producer and consumer ) during initialization of health check.

# PR Checklist Forms

- [X] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
