### PR TITLE
Hardening check for ensuring KStream store is available during IT phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Populated the HealthCheck stream region from config file. Removed the dependency of MPAAS_REGION variable. (#103)
 - Refactored the Exception handling workflow in order to better communicate the actual error to customers. (#111)  
+- Hardening check for ensuring KStream store is available during Integration Tests
 
 ## [0.4.4] - 20190204
 ### Changed

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/health/StreamRegistryHealthCheck.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -73,6 +74,10 @@ public class StreamRegistryHealthCheck extends HealthCheck {
     private int replicationFactor;
     private int partitions;
 
+    private Stream streamRegHealthCheckStream;
+    private ProducerResource producerResource;
+    private ConsumerResource consumerResource;
+
     public StreamRegistryHealthCheck(ManagedKStreams managedKStreams, StreamResource streamResource, MetricRegistry metricRegistry,
                                      HealthCheckStreamConfig healthCheckStreamConfig) {
         super();
@@ -95,6 +100,15 @@ public class StreamRegistryHealthCheck extends HealthCheck {
         metricRegistry.register(Metrics.PRODUCER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isProducerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.CONSUMER_REGISTRATION_HEALTH.getName(), (Gauge<Integer>)() -> isConsumerRegistrationHealthy() ? 1 : 2);
         metricRegistry.register(Metrics.STATE_STORE_STATE.getName(), (Gauge<String>)() -> getKstreamsState().toString());
+
+        streamRegHealthCheckStream = createCanaryStream();
+        streamResource.upsertStream(streamName, streamRegHealthCheckStream);
+
+        consumerResource = streamResource.getConsumerResource();
+        consumerResource.upsertConsumer(streamName, "C1", region);
+
+        producerResource = streamResource.getProducerResource();
+        producerResource.upsertProducer(streamName, "P1", region);
     }
 
     private synchronized boolean isStreamCreationHealthy() {
@@ -242,9 +256,13 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateProducerRegistration() {
         try {
-            ProducerResource producerResource = streamResource.getProducerResource();
-            String producerName = "P1";
-            Response response = producerResource.upsertProducer(streamName, producerName, region);
+            Response response = producerResource.getProducer(streamName, "P1");
+
+            if(response.getStatus() != Status.OK.getStatusCode()) {
+                setProducerRegistrationHealthy(false);
+                throw new IllegalStateException(String.format("HealthCheck Failed: Producer P1 Not Found. HEALTH_CHECK_STREAM_NAME=%s", streamName));
+            }
+
             List<RegionStreamConfig> regionStreamConfigList = ((Producer)response.getEntity()).getRegionStreamConfigList();
 
             if (regionStreamConfigList != null && regionStreamConfigList.size() > 0) {
@@ -276,9 +294,13 @@ public class StreamRegistryHealthCheck extends HealthCheck {
 
     private void validateConsumerRegistration() {
         try {
-            ConsumerResource consumerResource = streamResource.getConsumerResource();
-            String consumerName = "C1";
-            Response response = consumerResource.upsertConsumer(streamName, consumerName, region);
+            Response response = consumerResource.getConsumer(streamName, "C1");
+
+            if(response.getStatus() != Status.OK.getStatusCode()) {
+                setProducerRegistrationHealthy(false);
+                throw new IllegalStateException(String.format("HealthCheck Failed: Consumer C1 Not Found. HEALTH_CHECK_STREAM_NAME=%s", streamName));
+            }
+
             List<RegionStreamConfig> regionStreamConfigList = ((Consumer)response.getEntity()).getRegionStreamConfigList();
 
             if (regionStreamConfigList != null && regionStreamConfigList.size() > 0) {

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -233,14 +233,14 @@ public class BaseResourceIT {
         consumerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryURL);
 
         log.info(
-            "sleep started. Sleep needed so that the processor's init method is called (KV store created) before servicing the HTTP requests.");
+            "Waiting for processor's init method tob called (KV store created) before servicing the HTTP requests.");
         long timeoutTimestamp = System.currentTimeMillis() + TEST_STARTUP_TIMEOUT_MS;
         while (!initialized.isDone() && System.currentTimeMillis() <= timeoutTimestamp) {
             Thread.sleep(10); // wait some cycles before checking again
         }
-        Preconditions.checkState(System.currentTimeMillis() <= timeoutTimestamp,
-            "Did not receive state store initialized signal, aborting.");
-        log.info("sleep completed.");
+        Preconditions.checkState(initialized.isDone(), "Did not receive state store initialized signal, aborting.");
+        Preconditions.checkState(managedKStreams.getStreams().state().isRunning(), "State store did not start. Aborting.");
+        log.info("Processor wait completed.");
 
         KafkaManager kafkaManager = new KafkaManagerImpl();
         String env = configuration.getEnv();


### PR DESCRIPTION
# stream-registry PR

Hardening Travis Build [#435](https://travis-ci.org/homeaway/stream-registry/builds/488854536) failure

### Changed
* Updated check to ensure KStream store is available during Integration Tests
* Updated StreamRegistryHealthCheck impl to instantiate infra building blocks ( health check stream, producer and consumer ) during initialization of health check.

# PR Checklist Forms

- [X] CHANGELOG.md updated
- [] Reviewer assigned
- [] PR assigned (presumably to submitter)
- [] Labels added (enhancement, bug, documentation) 
