### PR TITLE
Handling NPE for getClusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.10] - SNAPSHOT
 ### Changed
+- Fixed a NPE in get clusters(#145)
 
 ## [0.4.9] - 20190321
 ### Changed

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
@@ -17,6 +17,7 @@ package com.homeaway.streamplatform.streamregistry.resource;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -148,10 +149,6 @@ public class ClusterResource extends BaseResource {
                     .filter(e -> e.getClusterKey().getType()!= null)
                     .filter(e -> e.getClusterKey().getType().equalsIgnoreCase(type))
                     .collect(Collectors.toList());
-            }
-            if (clusterList.isEmpty()) {
-                return Response
-                    .status(Response.Status.NOT_FOUND.getStatusCode()).build();
             }
             return Response.status(Response.Status.OK.getStatusCode()).entity(clusterList).build();
         } catch (IllegalStateException e) {

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
@@ -145,10 +145,14 @@ public class ClusterResource extends BaseResource {
 
             if(type != null && !type.isEmpty()) {
                 clusterList = clusterList.stream()
+                    .filter(e -> e.getClusterKey().getType()!= null)
                     .filter(e -> e.getClusterKey().getType().equalsIgnoreCase(type))
                     .collect(Collectors.toList());
             }
-
+            if (clusterList.isEmpty()) {
+                return Response
+                    .status(Response.Status.NOT_FOUND.getStatusCode()).build();
+            }
             return Response.status(Response.Status.OK.getStatusCode()).entity(clusterList).build();
         } catch (IllegalStateException e) {
             return buildErrorMessage(Response.Status.BAD_REQUEST, e);

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
@@ -17,7 +17,6 @@ package com.homeaway.streamplatform.streamregistry.resource;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -150,7 +149,7 @@ public class ClusterResource extends BaseResource {
                     .filter(e -> e.getClusterKey().getType().equalsIgnoreCase(type))
                     .collect(Collectors.toList());
             }
-            
+
             return Response.status(Response.Status.OK.getStatusCode()).entity(clusterList).build();
         } catch (IllegalStateException e) {
             return buildErrorMessage(Response.Status.BAD_REQUEST, e);

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/resource/ClusterResource.java
@@ -150,6 +150,7 @@ public class ClusterResource extends BaseResource {
                     .filter(e -> e.getClusterKey().getType().equalsIgnoreCase(type))
                     .collect(Collectors.toList());
             }
+            
             return Response.status(Response.Status.OK.getStatusCode()).entity(clusterList).build();
         } catch (IllegalStateException e) {
             return buildErrorMessage(Response.Status.BAD_REQUEST, e);


### PR DESCRIPTION
# stream-registry PR

Fixes Null Pointer Exception in getClusters

### Changed
- Added Null check in the filtering of the results to handle null pointer exception.
- Fixes bug #146 

# PR Checklist Forms

- [X] CHANGELOG.md updated
- [X] Reviewer assigned
- [X] PR assigned (presumably to submitter)
- [X] Labels added (enhancement, bug, documentation) 
